### PR TITLE
Upgrade Castle Game Engine usage

### DIFF
--- a/src/castleline2d.pas
+++ b/src/castleline2d.pas
@@ -222,7 +222,7 @@ var
     ResultCoord:TVector2List;// Для сборки всех элементов линии попорядку
     List3:TVector3List;      // для добавления в FGeometry
     isCross:boolean;         // для построени я трапеций. есть ли пересечения прямоугольников
-    Indexes:TLongIntList;    // для добавления в FGeometry
+    Indexes:TInt32List;    // для добавления в FGeometry
     // для текстурных координат
     CurTex:single; // текущее положение текстурных координат по оси X
     len:single;
@@ -255,7 +255,7 @@ begin
    BeginEnds:=TVector2List.Create;
    Triangles:=TVector2List.Create;
    List3:=TVector3List.Create;
-   Indexes:=TLongIntList.Create;
+   Indexes:=TInt32List.Create;
    Joins:=TVector2List.Create;
    // для текстурных координат
    if (Self.Texture<>'')and(FTexCoordMode<>cmDefault) then begin

--- a/src/castleline2dgizmos.pas
+++ b/src/castleline2dgizmos.pas
@@ -114,7 +114,6 @@ constructor TCastleLine2DGizmos.Create(AOwner: TComponent);
 begin
   inherited;
   Line:=nil;
-  Setup2D;
   Self.SetTransient;
   Hide;
 
@@ -129,7 +128,6 @@ begin
   Collides := false;
   Pickable := true;
   CastShadows := false;
-  ExcludeFromStatistics := true;
   InternalExcludeFromParentBoundingVolume := true;
 
 

--- a/src/castleline2dgizmos.pas
+++ b/src/castleline2dgizmos.pas
@@ -370,28 +370,34 @@ var
   GPoints:TPolypoint2DNode;
   ShapePoints:TShapeNode;
   MaterialPoints:TMaterialNode;
+  AppearancePoints:TAppearanceNode;
   {Точка для вставки}
   GInsertPoint:TPolypoint2DNode;
   ShapeInsertPoint:TShapeNode;
   MaterialInsertPoint:TMaterialNode;
+  AppearanceInsertPoint:TAppearanceNode;
   {Выделенная точка}
   GSelectPoint:TPolypoint2DNode;
   ShapeSelectPoint:TShapeNode;
   MaterialSelectPoint:TMaterialNode;
+  AppearanceSelectPoint:TAppearanceNode;
   {Линии }
   GLines:TPolyline2DNode;
   ShapeLines:TShapeNode;
   MaterialLines:TMaterialNode;
+  AppearanceLines:TAppearanceNode;
   {Граница, в которой можно редактировать}
   GBorder:TPolyline2DNode;
   ShapeBorder:TShapeNode;
   MaterialBorder:TMaterialNode;
+  AppearanceBorder:TAppearanceNode;
   {Текст для обозначения номеров вершин}
   TextTransform:TTransformNode;
   GText:TTextNode;
   ShapeText:TShapeNode;
   Font:TFontStyleNode;
   MaterialText:TMaterialNode;
+  AppearanceText:TAppearanceNode;
 
   i:integer;
   MaxXY,MinXY:TVector2;
@@ -422,7 +428,9 @@ begin
   GBorder.SetLineSegments([MinXY,Vector2(MinXY.X,MaxXY.Y),MaxXY,Vector2(MaxXY.X,MinXY.Y),MinXY]);
   MaterialBorder:=TMaterialNode.Create;
   MaterialBorder.EmissiveColor := RedRGB;
-  ShapeBorder.Material := MaterialBorder;
+  AppearanceBorder := TAppearanceNode.Create;
+  AppearanceBorder.Material := MaterialBorder;
+  ShapeBorder.Appearance := AppearanceBorder;
 
 
   //линии
@@ -430,27 +438,35 @@ begin
   GLines.SetLineSegments(Line.Points);
   MaterialLines := TMaterialNode.Create;
   MaterialLines.EmissiveColor := RedRGB;
-  ShapeLines.Material := MaterialLines;
+  AppearanceLines := TAppearanceNode.Create;
+  AppearanceLines.Material := MaterialLines;
+  ShapeLines.Appearance := AppearanceLines;
   // точки вершин
   GPoints:=TPolypoint2DNode.CreateWithShape(ShapePoints);
   GPoints.SetPoint(Line.Points);
   MaterialPoints := TMaterialNode.Create;
   MaterialPoints.EmissiveColor := RedRGB;
-  ShapePoints.Material := MaterialPoints;
+  AppearancePoints := TAppearanceNode.Create;
+  AppearancePoints.Material := MaterialPoints;
+  ShapePoints.Appearance := AppearancePoints;
   // выделенная точка
   if FSelectPoint>=0 then begin;
    GSelectPoint:=TPolypoint2DNode.CreateWithShape(ShapeSelectPoint);
    GSelectPoint.SetPoint(Line.Points[FSelectPoint]);
    MaterialSelectPoint:=TMaterialNode.Create;
    MaterialSelectPoint.EmissiveColor := GrayRGB;
-   ShapeSelectPoint.Material:=MaterialSelectPoint;
+   AppearanceSelectPoint := TAppearanceNode.Create;
+   AppearanceSelectPoint.Material := MaterialSelectPoint;
+   ShapeSelectPoint.Appearance := AppearanceSelectPoint;
    TransformNode.AddChildren(ShapeSelectPoint);
    // текст
    if World.MainCamera.ProjectionType=ptOrthographic then begin
     GText:=TTextNode.CreateWithTransform(ShapeText,TextTransform);
     MaterialText:=TMaterialNode.Create;
     MaterialText.EmissiveColor := RedRGB;
-    ShapeText.Material:=MaterialText;
+    AppearanceText := TAppearanceNode.Create;
+    AppearanceText.Material := MaterialText;
+    ShapeText.Appearance := AppearanceText;
     GText.SetText([FSelectPoint.ToString]);
     Font:=TFontStyleNode.Create;
     Font.Size:=FONT_SIZE;
@@ -467,7 +483,9 @@ begin
    GInsertPoint.SetPoint(FInsertPoint);
    MaterialInsertPoint:=TMaterialNode.Create;
    MaterialInsertPoint.EmissiveColor := BlueRGB;
-   ShapeInsertPoint.Material:=MaterialInsertPoint;
+   AppearanceInsertPoint := TAppearanceNode.Create;
+   AppearanceInsertPoint.Material := MaterialInsertPoint;
+   ShapeInsertPoint.Appearance := AppearanceInsertPoint;
    TransformNode.AddChildren(ShapeInsertPoint);
   end;
 

--- a/src/castleline2dgizmos.pas
+++ b/src/castleline2dgizmos.pas
@@ -228,7 +228,10 @@ end;
 
 function TCastleLine2DGizmos.Release(const E: TInputPressRelease): boolean;
 begin
-    if E.IsKey(keyShift) then isShift:=false;
+  Result:=inherited;
+  if Result then Exit;
+
+  if E.IsKey(keyShift) then isShift:=false;
 end;
 
 function TCastleLine2DGizmos.Press(const E: TInputPressRelease): boolean;

--- a/src/castlepolygon2d.pas
+++ b/src/castlepolygon2d.pas
@@ -160,7 +160,7 @@ end;
 
 procedure TCastlePolygon2D.ReLoad;
 var
-  Indexes:TLongIntList;    // для добавления в FGeometry
+  Indexes:TInt32List;    // для добавления в FGeometry
   List3:TVector3List;      // для добавления в FGeometry
   TexCoord:TVector2List;   // текстурные координаты
   i:integer;
@@ -171,7 +171,7 @@ begin
    Exit;
   end;
   List3:=TVector3List.Create;
-  Indexes:=TLongIntList.Create;
+  Indexes:=TInt32List.Create;
   if (Self.Texture<>'')and(FTexCoordMode<>cmDefault) then begin
     TexCoord:=TVector2List.Create;
   end;


### PR DESCRIPTION
This PR upgrades CGE usage.

Most importantly, I just pushed a significant change to CGE that has to break compatibility -- `TCastleScene.Setup2D` and `ExludeFromStatistics` no longer exist. More about it on https://castle-engine.io/wp/2023/06/30/big-renderer-improvements-correct-and-automatic-blending-sorting-more-powerful-batching-now-cross-scene-easier-and-more-reliable-occlusion-culling-and-occlusion-sorting/ .

Some other smaller things improved:

- Use `TShapeNode.Appearance`, not `TShapeNode.Material`. The `TShapeNode.Material` was a "smart shortcut" (auto-creating appearance node when set) but it caused some confusing behaviors, so ultimately we decided to deprecate it.

- Use `TInt32List` instead of `TLongIntList`. `TLongIntList` was deprecated in CGE because of https://castle-engine.io/coding_conventions#no_longint_longword

- Make `TCastleLine2DGizmos.Release` result defined. (FPC was correctly warning it is undefined.)