### PR TITLE
3 fixes to Castle Game Engine usage

### DIFF
--- a/src/castleline2d.pas
+++ b/src/castleline2d.pas
@@ -222,7 +222,7 @@ var
     ResultCoord:TVector2List;// Для сборки всех элементов линии попорядку
     List3:TVector3List;      // для добавления в FGeometry
     isCross:boolean;         // для построени я трапеций. есть ли пересечения прямоугольников
-    Indexes:TLongIntList;    // для добавления в FGeometry
+    Indexes:TInt32List;    // для добавления в FGeometry
     // для текстурных координат
     CurTex:single; // текущее положение текстурных координат по оси X
     len:single;
@@ -255,7 +255,7 @@ begin
    BeginEnds:=TVector2List.Create;
    Triangles:=TVector2List.Create;
    List3:=TVector3List.Create;
-   Indexes:=TLongIntList.Create;
+   Indexes:=TInt32List.Create;
    Joins:=TVector2List.Create;
    // для текстурных координат
    if (Self.Texture<>'')and(FTexCoordMode<>cmDefault) then begin

--- a/src/castleline2dgizmos.pas
+++ b/src/castleline2dgizmos.pas
@@ -114,7 +114,6 @@ constructor TCastleLine2DGizmos.Create(AOwner: TComponent);
 begin
   inherited;
   Line:=nil;
-  Setup2D;
   Self.SetTransient;
   Hide;
 
@@ -129,7 +128,6 @@ begin
   Collides := false;
   Pickable := true;
   CastShadows := false;
-  ExcludeFromStatistics := true;
   InternalExcludeFromParentBoundingVolume := true;
 
 

--- a/src/castleline2dgizmos.pas
+++ b/src/castleline2dgizmos.pas
@@ -226,6 +226,8 @@ end;
 
 function TCastleLine2DGizmos.Release(const E: TInputPressRelease): boolean;
 begin
+  Result := inherited;
+
     if E.IsKey(keyShift) then isShift:=false;
 end;
 

--- a/src/castlepolygon2d.pas
+++ b/src/castlepolygon2d.pas
@@ -160,7 +160,7 @@ end;
 
 procedure TCastlePolygon2D.ReLoad;
 var
-  Indexes:TLongIntList;    // для добавления в FGeometry
+  Indexes:TInt32List;    // для добавления в FGeometry
   List3:TVector3List;      // для добавления в FGeometry
   TexCoord:TVector2List;   // текстурные координаты
   i:integer;
@@ -171,7 +171,7 @@ begin
    Exit;
   end;
   List3:=TVector3List.Create;
-  Indexes:=TLongIntList.Create;
+  Indexes:=TInt32List.Create;
   if (Self.Texture<>'')and(FTexCoordMode<>cmDefault) then begin
     TexCoord:=TVector2List.Create;
   end;


### PR DESCRIPTION
3 code changes to work perfectly with latest Castle Game Engine :)

1. (Important): To fix compilation with latest Castle Game Engine, where we removed the `Setup2D` method on scene and `ExcludeFromStatistics` during the refactor of renderer, see https://castle-engine.io/wp/2023/06/30/big-renderer-improvements-correct-and-automatic-blending-sorting-more-powerful-batching-now-cross-scene-easier-and-more-reliable-occlusion-culling-and-occlusion-sorting/
2. FPC was rightly warning that one `Release` method result was undefined.
3. (Minor) Changed TLongIntList usage to TInt32List usage. The TLongIntList is deprecated in CGE because of https://castle-engine.io/coding_conventions#no_longint_longword